### PR TITLE
feat: add Waafi Pay HPP service

### DIFF
--- a/backend/app/Services/Domain/Payment/Waafi/WaafiPayHppService.php
+++ b/backend/app/Services/Domain/Payment/Waafi/WaafiPayHppService.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace HiEvents\Services\Domain\Payment\Waafi;
+
+use Illuminate\Config\Repository;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Client\RequestException;
+use Psr\Log\LoggerInterface;
+
+readonly class WaafiPayHppService
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private Factory $httpClient,
+        private Repository $config,
+    ) {}
+
+    /**
+     * Initiate a WaafiPay HPP payment and return the redirect URL.
+     *
+     * @throws RequestException
+     */
+    public function initiatePayment(array $payload): string
+    {
+        $endpoint = $this->config->get('services.waafipay.endpoint');
+
+        $payload['success_url'] = route('waafipay.success');
+        $payload['cancel_url'] = route('waafipay.cancel');
+
+        $response = $this->httpClient->post($endpoint, $payload);
+
+        if ($response->failed()) {
+            $this->logger->error('WaafiPay HPP request failed', [
+                'payload' => $payload,
+                'response' => $response->body(),
+            ]);
+
+            $response->throw();
+        }
+
+        return $response->json('payment_url');
+    }
+}


### PR DESCRIPTION
## Summary
- add WaafiPayHppService with logger, HTTP client factory and config repository
- use Laravel route helpers for WaafiPay success and cancel URLs

## Testing
- `vendor/bin/pint app/Services/Domain/Payment/Waafi/WaafiPayHppService.php`
- `vendor/bin/phpunit tests/Feature/Auth/LoginTest.php` *(fails: connection to server at 127.0.0.1, port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_688dfacdfc0883209af208732623893a