### PR TITLE
feat(frontend): clarify WaafiPay integration

### DIFF
--- a/frontend/src/components/routes/event/Settings/Sections/PaymentSettings/index.tsx
+++ b/frontend/src/components/routes/event/Settings/Sections/PaymentSettings/index.tsx
@@ -166,6 +166,19 @@ export const PaymentAndInvoicingSettings = () => {
                                     />
                                 </Card>
                             )}
+
+                            {form.values.payment_providers?.includes("WAAFIPAY") && (
+                                <Card style={{boxShadow: 'none', marginTop: '20px'}}>
+                                    <h4 style={{
+                                        marginTop: '5px',
+                                        marginBottom: '10px'
+                                    }}>{t`WaafiPay Payments`}</h4>
+                                    <MantineCard shadow="sm" padding="lg" radius="md" withBorder>
+                                        <Text size="sm" mt="xs">{t`When WaafiPay is enabled, attendees will be redirected to the WaafiPay hosted payment page to complete their purchase.`}</Text>
+                                        <Text size="sm" mt="xs">{t`Ensure your WaafiPay merchant credentials are configured on the server before enabling this option.`}</Text>
+                                    </MantineCard>
+                                </Card>
+                            )}
                         </Paper>
 
                         <Paper withBorder p="md" radius="md">


### PR DESCRIPTION
## Summary
- show WaafiPay payment information card on event settings page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 548 problems (303 errors, 245 warnings))*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: requires ext-sodium; instructed to install extension)*
- `apt-get update` *(fails: 403 Forbidden from repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689748858dd08320822b69ca891a0685